### PR TITLE
fix: change content-type in blob 

### DIFF
--- a/pages/stamp/[id].tsx
+++ b/pages/stamp/[id].tsx
@@ -56,7 +56,9 @@ const ListedStamp = ({ stamp }: { stamp: StampWithLikes }) => {
       return
     }
     const file = await res.blob()
-    triggerDownload(file, stamp.title)
+    //FIXME: files responding with text/html
+    const newFile = file.slice(0, file.size, 'application/octet-stream')
+    triggerDownload(newFile, stamp.title)
     await fetch(`/api/stamp/download/${stamp.id}`)
   }
 


### PR DESCRIPTION
hack to deal with incorrectly set content-type files