### PR TITLE
remove default on primary key id on stamp table

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,7 +23,7 @@ model Image {
 }
 
 model Stamp {
-  id           String   @id @default(cuid())
+  id           String   @id
   userId       String
   game         String
   title        String


### PR DESCRIPTION
even when explicitly assigned in create statement, the default on prisma schema still overrides the assigned id.