### PR TITLE
fix: stamp card ui

### DIFF
--- a/cypress/e2e/home_page.cy.ts
+++ b/cypress/e2e/home_page.cy.ts
@@ -2,11 +2,4 @@ describe('Home Page', () => {
   beforeEach(() => {
     cy.visit('/')
   })
-
-  it('liking stamp opens auth modal for unauthorized users', () => {
-    cy.getBySel('auth-modal').should('not.exist')
-    cy.get('article').first().findByRole('button').click()
-
-    cy.getBySel('auth-modal').should('be.visible')
-  })
 })

--- a/src/components/StampCard.tsx
+++ b/src/components/StampCard.tsx
@@ -1,11 +1,14 @@
-import { UserCircleIcon, WrenchIcon } from '@heroicons/react/24/solid'
+import {
+  ArrowDownTrayIcon,
+  UserCircleIcon,
+  WrenchIcon,
+} from '@heroicons/react/24/solid'
 import Image from 'next/image'
 import Link from 'next/link'
 
 import type { StampWithRelations } from '@/lib/prisma/queries'
 
 import Category from './Category'
-import LikeButton from './LikeButton'
 
 const StampCard = ({
   id,
@@ -14,8 +17,7 @@ const StampCard = ({
   region,
   modded,
   imageUrl,
-  collection,
-  likedBy,
+  downloads,
   images,
   user,
 }: StampWithRelations) => {
@@ -25,76 +27,65 @@ const StampCard = ({
       : images[0].thumbnailUrl ?? images[0].originalUrl
 
   return (
-    <article className="grid w-full grid-flow-row rounded-lg bg-white shadow-md">
+    <div className="rounded-lg bg-white shadow-md">
       <Link href={`/stamp/${id}`} data-testid="stamp-card-link">
-        <div className="relative">
-          <div className="aspect-h-9 aspect-w-16 overflow-hidden rounded-tl-lg rounded-tr-lg bg-gray-200">
-            <div>
-              <Image
-                src={srcUrl}
-                alt={title ?? 'image alt'}
-                className="transition hover:opacity-80"
-                fill
-                sizes="(max-width: 320px) 700px
+        <div className="aspect-h-3 aspect-w-4 overflow-hidden rounded-tl-lg rounded-tr-lg bg-gray-200">
+          <Image
+            src={srcUrl}
+            alt={title ?? 'image alt'}
+            className="transition hover:opacity-80"
+            fill
+            sizes="(max-width: 320px) 700px
                 (max-width: 768px) 390px,
                 (max-width: 1200px) 290px"
-                style={{
-                  objectFit: 'cover',
-                }}
-              />
-              {modded && (
-                <span className="absolute right-2 top-2 flex flex-row items-center rounded-full bg-[#6DD3C0] px-2 py-1 text-xs text-black">
-                  <WrenchIcon className="mr-1 h-3 w-3" />
-                  mods
-                </span>
-              )}
-            </div>
-          </div>
-        </div>
-        <div className="flex flex-col flex-nowrap p-4">
-          <div className="flex justify-between">
-            <span
-              id="stamp-region"
-              className="pb-2 text-sm capitalize text-[#B11E47]"
-            >
-              {region}
+            style={{
+              objectFit: 'cover',
+            }}
+          />
+          {modded && (
+            <span className="absolute right-2 top-2 flex h-fit w-fit flex-row items-center rounded-full bg-[#6DD3C0] px-2 py-1 text-xs text-black">
+              <WrenchIcon className="mr-1 h-3 w-3" />
+              mods
             </span>
-            {collection && (
-              <span className="flex w-fit items-center gap-1 rounded-full bg-[#6DD3C0] py-1 pl-2 pr-3 text-xs capitalize text-black">
-                Collection
-              </span>
-            )}
-          </div>
+          )}
+        </div>
+      </Link>
+      <div className="flex flex-col flex-nowrap gap-y-2 p-4">
+        <Link href={`/stamp/${id}`}>
+          <h4 id="stamp-region" className=" text-[#B11E47]">
+            {region}
+          </h4>
 
           <h2
             id="stamp-title"
-            className="mt-2 w-full text-lg font-semibold leading-tight text-gray-700"
+            className="line-clamp-2 min-h-[45px] w-full overflow-hidden text-ellipsis text-lg font-semibold leading-tight text-gray-700"
           >
             {title}
           </h2>
-        </div>
-      </Link>
-      {user?.username && (
-        <Link
-          href={`/${user.usernameURL}`}
-          className="flex items-center gap-1 p-4 py-2 text-slate-500"
-        >
-          <UserCircleIcon className="h-4 w-4" />
-          <span className="hover:text-sky-700">{user.username}</span>
         </Link>
-      )}
-      <div className="flex flex-col flex-nowrap self-end p-4">
-        <ol className="relative flex flex-row justify-between pt-4 text-gray-500">
-          <li>
-            <Category category={category} />
-          </li>
 
-          <li>
-            <LikeButton id={id} likedBy={likedBy} />
-          </li>
-        </ol>
+        {user?.username ? (
+          <Link
+            href={`/${user.usernameURL}`}
+            className="flex h-11 items-center gap-1 text-slate-500"
+          >
+            <UserCircleIcon className="h-4 w-4" />
+            <span className="hover:text-sky-700">{user.username}</span>
+          </Link>
+        ) : (
+          <Link href={`/stamp/${id}`} className="h-11" />
+        )}
+        <Link href={`/stamp/${id}`}>
+          <div className="flex justify-between">
+            <Category category={category} />
+            <div className="flex items-end">
+              <ArrowDownTrayIcon className="mr-2 inline-block h-5 w-5 self-center" />
+              {downloads}
+            </div>
+          </div>
+        </Link>
       </div>
-    </article>
+    </div>
   )
 }
 

--- a/src/components/__tests__/StampCard.test.tsx
+++ b/src/components/__tests__/StampCard.test.tsx
@@ -22,6 +22,7 @@ describe('Stamp Card', () => {
       title: 'Stamp Title',
       category: 'production',
       region: 'old world',
+      downloads: 123,
       modded: true,
       user: { ...stamp.user, username: 'stampCreator' },
       likedBy: [{ ...stamp.likedBy[0] }, { ...stamp.likedBy[0] }],
@@ -33,11 +34,10 @@ describe('Stamp Card', () => {
     )
     expect(screen.getByAltText('Stamp Title')).toBeInTheDocument()
     expect(screen.getByText('mods')).toBeInTheDocument()
-    expect(screen.getByText('Collection')).toBeInTheDocument()
+    expect(screen.getByText('123')).toBeInTheDocument()
     expect(screen.getByText('production')).toBeInTheDocument()
     expect(screen.getByText('old world')).toBeInTheDocument()
     expect(screen.getByText('stampCreator')).toBeInTheDocument()
-    expect(screen.getByText('2')).toBeInTheDocument()
   })
 
   it('hidden mod and collection badge when false', () => {


### PR DESCRIPTION
remove LikeButton from card as checking for auth/liked stamp on every rendered element is bad (current implementation)
add downloads count instead

fix various ui errors including

- Super long titles without spaces would escape container and flow over effecting img
- Titles longer then 2 lines would increase the size of all cards on row
- Titles longer then 2 lines are truncated
- better rendering of stamps without username set