### PR TITLE
fix: thumbnail generation is way too blurry still

### DIFF
--- a/src/components/StampCard.tsx
+++ b/src/components/StampCard.tsx
@@ -24,7 +24,7 @@ const StampCard = ({
   const srcUrl =
     images.length === 0
       ? imageUrl ?? 'https://placehold.co/250x250/png'
-      : images[0].thumbnailUrl ?? images[0].originalUrl
+      : images[0].smallUrl ?? images[0].originalUrl
 
   return (
     <div className="rounded-lg bg-white shadow-md">


### PR DESCRIPTION
Depending on the original uploaded image, thumbnails are still unacceptably blurry.

Approximate optimisation for a 1 MB image is still down to 100 kB