### PR TITLE
fix: stamp page update time displays incorrect information

### DIFF
--- a/prisma/migrations/20240311140231_set_default_on_changed_at/migration.sql
+++ b/prisma/migrations/20240311140231_set_default_on_changed_at/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - Made the column `changedAt` on table `Stamp` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "Stamp" ALTER COLUMN "changedAt" SET NOT NULL,
+ALTER COLUMN "changedAt" SET DEFAULT CURRENT_TIMESTAMP;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,7 +40,7 @@ model Stamp {
   townhall     Boolean   @default(false)
   tradeUnion   Boolean   @default(false)
   createdAt    DateTime  @default(now())
-  changedAt    DateTime?
+  changedAt    DateTime  @default(now())
   updatedAt    DateTime  @updatedAt
   modded       Boolean   @default(false)
   downloads    Int       @default(0)

--- a/src/__tests__/pages/stamp/StampPage.test.tsx
+++ b/src/__tests__/pages/stamp/StampPage.test.tsx
@@ -21,6 +21,7 @@ const stamp = {
   townhall: false,
   tradeUnion: true,
   createdAt: 1695253939,
+  changedAt: 1695253939,
   updatedAt: 1695253939,
   modded: true,
   downloads: 999,
@@ -106,7 +107,7 @@ describe('Stamp Page', () => {
   })
   it('displays stamp updated time', () => {
     render({
-      updatedAt: 1709404300,
+      changedAt: 1709404300,
     })
 
     expect(screen.getByText('Updated:', { exact: false })).toBeInTheDocument()

--- a/src/lib/prisma/queries.ts
+++ b/src/lib/prisma/queries.ts
@@ -18,8 +18,9 @@ export interface StampWithRelations
     Prisma.StampGetPayload<{
       include: typeof stampIncludeStatement
     }>,
-    'createdAt' | 'updatedAt' | 'images'
+    'createdAt' | 'updatedAt' | 'images' | 'changedAt'
   > {
+  changedAt: number
   createdAt: number
   images: Image[]
   updatedAt: number
@@ -86,7 +87,9 @@ const createStampSchema = stampSchema
 >
 
 const updateStampSchema = stampSchema
-  .partial()
+  .omit({ id: true, userId: true, game: true })
+  .partial({ images: true })
+  .extend({ changedAt: z.string().datetime() })
   .transform(({ modded, tradeUnion, townhall, collection, ...schema }) => ({
     modded: modded === 'true',
     tradeUnion: tradeUnion === 'true',

--- a/src/lib/prisma/queries.ts
+++ b/src/lib/prisma/queries.ts
@@ -132,6 +132,11 @@ export const stampExtensions = Prisma.defineExtension({
           return getUnixTime(new Date(updatedAt))
         },
       },
+      changedAt: {
+        compute({ changedAt }) {
+          return getUnixTime(new Date(changedAt))
+        },
+      },
     },
   },
 })

--- a/src/pages/api/stamp/update.ts
+++ b/src/pages/api/stamp/update.ts
@@ -74,6 +74,7 @@ export default async function updateStampHandler(
             }),
           },
         }),
+        changedAt: new Date().toISOString(),
         ...fields,
       },
     })

--- a/src/pages/stamp/[id].tsx
+++ b/src/pages/stamp/[id].tsx
@@ -108,7 +108,7 @@ const StampPage = ({ stamp }: { stamp: StampWithRelations }) => {
     collection,
     likedBy,
     createdAt,
-    updatedAt,
+    changedAt,
   } = stamp
 
   return (
@@ -166,9 +166,9 @@ const StampPage = ({ stamp }: { stamp: StampWithRelations }) => {
           </a>
         </div>
 
-        {createdAt !== updatedAt && (
+        {createdAt !== changedAt && (
           <div className="italic">
-            Updated: {distanceUnixTimeToNow(updatedAt)}
+            Updated: {distanceUnixTimeToNow(changedAt)}
           </div>
         )}
         <p className="col-span-3 break-words text-lg">{description}</p>


### PR DESCRIPTION
follows #286 

- [X] run query update "stamp" set changedAt = createdAt on database

