### PR TITLE
Revert "chore: use clsx/lite string only version (#528)"

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { type ClassValue, clsx } from 'clsx/lite'
+import { ClassValue, clsx } from 'clsx'
 import { formatDistanceToNowStrict, fromUnixTime } from 'date-fns'
 import { twMerge } from 'tailwind-merge'
 


### PR DESCRIPTION
This reverts commit 9c46029ba277a2c1316b2334f3938192f5045747.